### PR TITLE
stricter checking

### DIFF
--- a/Stopwatch.php
+++ b/Stopwatch.php
@@ -87,7 +87,7 @@ class Stopwatch implements ResetInterface
     {
         $this->stop('__section__');
 
-        if (1 == \count($this->activeSections)) {
+        if (1 === \count($this->activeSections)) {
             throw new \LogicException('There is no started section to stop.');
         }
 

--- a/StopwatchEvent.php
+++ b/StopwatchEvent.php
@@ -98,7 +98,7 @@ class StopwatchEvent
      */
     public function stop()
     {
-        if (!\count($this->started)) {
+        if (0 === \count($this->started)) {
             throw new \LogicException('stop() called but start() has not been called before.');
         }
 


### PR DESCRIPTION
stricter checking in parts makes it a little clearer what the expected result in the if block should be, also as the return type of count, is an int it also makes these if blocks more clear.